### PR TITLE
feat: id proposal

### DIFF
--- a/content/docs/architecture/identifiers/_index.md
+++ b/content/docs/architecture/identifiers/_index.md
@@ -1,0 +1,58 @@
+---
+title: Identifiers
+weight: 42
+bookCollapseSection: true
+---
+
+# Identifiers
+
+In W3DS, every person, group, device, and data store has a name. That name is
+called a **W3ID**. This section explains what a W3ID is, how it stays the same
+over a person's lifetime, and how new ones are created without two people
+ending up with the same one.
+
+The full requirements this section is meant to satisfy live here:
+[W3ID and eName Requirements](https://github.com/w3ds-docs/w3ds-docs/wiki/W3ID-eName-Requirements).
+
+> **In plain terms**
+>
+> A W3ID is a name that computers use to find someone or something. People
+> have one. Groups have one. Each [eVault](/docs/Infrastructure/eVault), which
+> is the data store that holds a person's information, has one. Every entry
+> inside an eVault has one. It is the single name that everything else in
+> W3DS uses to point at the same thing.
+
+## Where W3IDs show up
+
+```mermaid
+flowchart LR
+    W3ID(("W3ID"))
+    User["Person"]
+    Group["Group"]
+    Device["Device"]
+    EVault["eVault<br/>(data store)"]
+    Entry["Entry inside an eVault"]
+
+    User --> W3ID
+    Group --> W3ID
+    Device --> W3ID
+    EVault --> W3ID
+    Entry --> W3ID
+```
+
+Every box on the left **has** a W3ID. That single W3ID is the only piece of
+text another computer needs to find the thing the box describes.
+
+## Two words you will see a lot
+
+- **W3ID**: the technical name for the identifier. Always a string of letters
+  and numbers in a fixed shape.
+- **eName**: a W3ID used for a **first-class citizen of the ecosystem**: a
+  person, organisation, group, device, or eVault controller. Every eName is
+  a global W3ID and is registered in the registry. The word "eName" is the
+  one used in public, name-like contexts, while "W3ID" is the technical
+  term that covers every identifier in the system, including the local ones
+  that live inside a single eVault.
+
+The next pages explain how a W3ID is written, why it never has to change, and
+how new ones are made.

--- a/content/docs/architecture/identifiers/anatomy.md
+++ b/content/docs/architecture/identifiers/anatomy.md
@@ -12,9 +12,9 @@ never pick the same one.
 
 > **In plain terms**
 >
-> Think of it as a serial number. It is long enough that no two people will
-> get the same one by accident. It has a fixed shape so software can recognise
-> it. It uses lowercase or uppercase, both are accepted.
+> It is just a long chain of characters. It is long enough that no two people
+> will get the same one by accident. It has a fixed shape so software can
+> recognise it. It uses lowercase or uppercase, both are accepted.
 
 ## The shape
 
@@ -105,11 +105,39 @@ Scoped local W3ID:          @e4d909c2-5d2f-4a7d-9473-b34b6c0f1a5a/f2a6743e-8d5b-
 ## Rules to remember
 
 - A W3ID **is** a UUID, written with the standard dashes. Case is ignored.
-- A global W3ID **starts with `@`**. A local one does not.
-- An **eName** is just a global W3ID that has been registered, so the rest
-  of W3DS can find it.
+- A global W3ID **starts with `@`** and **is registered in a registry**, so
+  the rest of W3DS can find it. A local one does neither.
+- An **eName** is a global W3ID whose subject is a first-class citizen of the
+  ecosystem: a person, organisation, group, device, or eVault controller.
+  Every eName is a registered global W3ID; not every registered global W3ID
+  is an eName.
 - The UUID space is huge (around 5 followed by 36 zeros), so the chance of
   two random W3IDs colliding is essentially zero. If we ever needed more
   room, the format leaves space for a bigger identifier later.
+
+## Free identifiers
+
+Not every identifier in the ecosystem points at something that can be looked
+up or owned. A plain word like `Paris` or `Communism` is also a valid
+identifier. It just does not behave like a W3ID: nobody owns it, no registry
+resolves it, and there is no eVault behind it.
+
+> **In plain terms**
+>
+> Some names refer to a specific, findable thing, like a person's eVault.
+> Other names refer to an idea or a place that everyone can mention but
+> nobody controls. Both are allowed. The difference is that the first kind
+> can be resolved to a real location and is owned by someone, while the
+> second kind is just a shared label whose meaning is left to whoever reads
+> it.
+
+So identifiers fall into two broad groups:
+
+- **Resolvable, owned identifiers**: W3IDs and eNames. They are registered,
+  they resolve to an eVault, and a controller is responsible for them.
+- **Free identifiers**: ordinary words and phrases. They need no resolution,
+  have no owner, and their meaning is a matter of interpretation. The
+  ecosystem allows them so that anything can be referred to, even things that
+  have no eVault and never will.
 
 For full format details, see the [W3ID prototype page](/docs/W3DS%20Basics/W3ID).

--- a/content/docs/architecture/identifiers/anatomy.md
+++ b/content/docs/architecture/identifiers/anatomy.md
@@ -1,0 +1,115 @@
+---
+title: What a W3ID looks like
+weight: 1
+---
+
+# What a W3ID looks like
+
+A W3ID is a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier),
+which is a long, random-looking string of letters and numbers. UUIDs are
+designed so that two computers generating them at random will almost certainly
+never pick the same one.
+
+> **In plain terms**
+>
+> Think of it as a serial number. It is long enough that no two people will
+> get the same one by accident. It has a fixed shape so software can recognise
+> it. It uses lowercase or uppercase, both are accepted.
+
+## The shape
+
+```mermaid
+flowchart LR
+    Prefix["@<br/>global marker"]
+    UUID["e4d909c2-5d2f-4a7d-9473-b34b6c0f1a5a<br/>(the UUID itself)"]
+    Slash["/<br/>optional"]
+    Local["object-uuid<br/>(an entry inside the eVault)"]
+
+    Prefix --> UUID --> Slash --> Local
+```
+
+Reading left to right:
+
+- **`@`** at the start means this is a **global** W3ID. Anyone in W3DS can
+  look it up.
+- The **UUID** is the random string. Dashes are always in the same places.
+  Case does not matter; the same UUID in upper case and lower case is the
+  same UUID.
+- **`/`** plus another UUID is optional. It points at one specific entry
+  inside that person's eVault, for example one post or one document.
+
+## The three classes
+
+There are three names you will hear for these identifiers. They all use the
+same UUID format; what differs is what they point at and who can use them.
+The picture below shows how the three sets relate.
+
+<p>
+<svg viewBox="0 0 640 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Venn diagram of identifier classes">
+  <rect x="10" y="10" width="620" height="360" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="6 6" rx="10"/>
+  <text x="24" y="34" font-size="14" fill="currentColor" font-weight="bold">All W3IDs</text>
+
+  <circle cx="220" cy="210" r="140" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="2"/>
+  <text x="220" y="95" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Global W3ID</text>
+  <text x="220" y="113" text-anchor="middle" font-size="12" fill="currentColor">starts with @</text>
+
+  <circle cx="240" cy="230" r="80" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="2"/>
+  <text x="240" y="210" text-anchor="middle" font-size="14" fill="currentColor" font-weight="bold">eName</text>
+  <text x="240" y="228" text-anchor="middle" font-size="11" fill="currentColor">for first-class citizens:</text>
+  <text x="240" y="242" text-anchor="middle" font-size="11" fill="currentColor">people, organisations,</text>
+  <text x="240" y="256" text-anchor="middle" font-size="11" fill="currentColor">groups, devices, eVaults</text>
+
+  <circle cx="490" cy="210" r="110" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="2"/>
+  <text x="490" y="195" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Local W3ID</text>
+  <text x="490" y="215" text-anchor="middle" font-size="12" fill="currentColor">no @, lives inside</text>
+  <text x="490" y="230" text-anchor="middle" font-size="12" fill="currentColor">one eVault</text>
+  <text x="490" y="252" text-anchor="middle" font-size="11" fill="currentColor" font-style="italic">can be promoted</text>
+  <text x="490" y="266" text-anchor="middle" font-size="11" fill="currentColor" font-style="italic">to a Global W3ID</text>
+</svg>
+</p>
+
+Read the picture this way:
+
+- The big dashed box is the whole world of W3IDs.
+- The **Global W3ID** circle on the left contains every identifier that
+  starts with `@`. **All Global W3IDs are registered in a registry**, that
+  is what makes them resolvable anywhere in W3DS.
+- Inside it, the smaller **eName** circle is reserved for the
+  **first-class citizens of the ecosystem**: people, organisations, groups,
+  devices, and eVault controllers. Every eName is a Global W3ID, but not
+  every Global W3ID is an eName: identifiers for ordinary internal
+  resources stay outside this inner circle.
+- The **Local W3ID** circle on the right is separate: those identifiers
+  only mean something inside one eVault and are not in the registry. A
+  Local W3ID can later be **promoted** into a Global W3ID if it needs to
+  be addressable elsewhere.
+
+- **Global W3ID**: starts with `@`. It can be looked up across W3DS and
+  points to an [eVault](/docs/Infrastructure/eVault).
+- **Local W3ID**: no `@`. It only means something inside one eVault, for
+  example "post number 7 in this user's eVault". It can be combined with the
+  owner's global W3ID to make it globally addressable:
+  `@owner-uuid/local-uuid`.
+- **eName**: an everyday word for a global W3ID that is registered in the
+  W3DS directory. People, groups, devices, and eVault controllers normally
+  have an eName.
+
+## Examples
+
+```text
+Global W3ID  (eName):       @e4d909c2-5d2f-4a7d-9473-b34b6c0f1a5a
+Local W3ID:                 f2a6743e-8d5b-43bc-a9f0-1c7a3b9e90d7
+Scoped local W3ID:          @e4d909c2-5d2f-4a7d-9473-b34b6c0f1a5a/f2a6743e-8d5b-43bc-a9f0-1c7a3b9e90d7
+```
+
+## Rules to remember
+
+- A W3ID **is** a UUID, written with the standard dashes. Case is ignored.
+- A global W3ID **starts with `@`**. A local one does not.
+- An **eName** is just a global W3ID that has been registered, so the rest
+  of W3DS can find it.
+- The UUID space is huge (around 5 followed by 36 zeros), so the chance of
+  two random W3IDs colliding is essentially zero. If we ever needed more
+  room, the format leaves space for a bigger identifier later.
+
+For full format details, see the [W3ID prototype page](/docs/W3DS%20Basics/W3ID).

--- a/content/docs/architecture/identifiers/lifecycle.md
+++ b/content/docs/architecture/identifiers/lifecycle.md
@@ -1,0 +1,193 @@
+---
+title: Creation, resolution, transfer, conflicts
+weight: 3
+---
+
+# Creation, resolution, transfer, conflicts
+
+A W3ID lives a whole life: it is created, it is looked up by other systems,
+it can be moved to a new eVault, and once in a while two people may
+accidentally pick the same one. This page walks through each of those four
+moments.
+
+## Creating a W3ID
+
+A new W3ID is normally created at the moment a person, group, or device gets
+their first eVault. The wallet app generates the UUID, asks a small set of
+independent **timestamp witnesses** to vouch for the creation time, and then
+hands the whole creation record to a registry.
+
+> **In plain terms**
+>
+> When you make a new W3ID, you do not just pick a name. You also gather
+> signed notes from several independent timestamp services saying "yes, this
+> name first appeared at this moment". That makes it very hard for someone
+> else to come along later and claim they had it first.
+
+```mermaid
+sequenceDiagram
+    participant Wallet as Wallet (yours)
+    participant Witnesses as Timestamp witnesses
+    participant Vault as eVault provisioning
+    participant Registry as Registry
+
+    Wallet->>Wallet: 1. Pick a UUID at random
+    Wallet->>Witnesses: 2. Ask several to timestamp it
+    Witnesses-->>Wallet: 3. Signed time stamps
+    Wallet->>Vault: 4. Create my eVault
+    Wallet->>Registry: 5. Register the eName with the creation record
+    Registry->>Registry: 6. Check nobody else has it already
+    Registry-->>Wallet: 7. Done
+```
+
+A few rules from the requirements:
+
+- The creation record **must** carry a creation timestamp.
+- The timestamp **should** be backed by signed witnesses, ideally a quorum
+  like **7 out of 10** independent witnesses, so a single rogue witness
+  cannot lie about the time.
+- The registry **must** do a best-effort check to see whether someone else
+  already registered the same name. The check is best-effort because a
+  conflict can still happen, see [Conflicts](#conflicts) below.
+
+### Reserving a W3ID for someone who is not on W3DS yet
+
+It is allowed to create a W3ID for a person, company, or organisation that
+is not yet using W3DS, for example so a friend can attach evidence about
+them. Those records carry identity evidence (a legal name, a passport
+number, an organisation registration, and so on) and still go through the
+duplicate check. This is a prototype-level feature.
+
+## Resolving a W3ID
+
+When another system wants to find you, it does not need to know where your
+eVault lives. It only needs your eName. The lookup goes through the
+registry, which is the directory that knows the current address of every
+registered eVault.
+
+```mermaid
+sequenceDiagram
+    participant Client as Some app
+    participant Registry as Registry
+    participant Vault as Your eVault
+
+    Client->>Registry: 1. Where is @e4d909c2-...?
+    Registry-->>Client: 2. Here is the eVault address
+    Client->>Vault: 3. Please give me entry /f2a6743e-...
+    Vault-->>Client: 4. Here it is
+```
+
+This is also why W3IDs do not depend on the regular internet domain name
+system (DNS): the identity layer needs to keep working even if a domain
+disappears.
+
+## Transferring to a new eVault
+
+You can switch eVault providers. Your eName does not change, but the
+registry needs to know that you have moved. This is done with a signed
+**transfer record**, not by quietly overwriting the old address.
+
+```mermaid
+flowchart LR
+    subgraph Before["Before"]
+        E1["Your eName"] --> V1["eVault A"]
+    end
+
+    subgraph After["After"]
+        E2["Your eName<br/>(same as before)"] --> T["Transfer record<br/>signed by previous owner<br/>+ authorisation evidence"]
+        T --> V2["eVault B"]
+        E2 -. original creation record kept .- C[("Genesis<br/>creation record")]
+    end
+
+    Before --> After
+```
+
+The transfer record carries:
+
+- the previous eVault, the new eVault, and the time the move took effect;
+- a reference to the original creation record (which is **never**
+  overwritten);
+- a hash of the transfer document;
+- signatures from the right people, plus any extra authorisation evidence
+  that the ecosystem accepts.
+
+A registry will only point your eName at the new eVault if the chain of
+transfer records links cleanly back to your original creation record.
+
+## Conflicts
+
+Sometimes two creations slip past the duplicate check, for example because
+two registries were temporarily out of touch. The W3ID requirements treat
+duplicates as **conflicts**, never as something to be quietly merged.
+
+The picture below shows what a conflict actually is: two registries each
+hold their own pile of records, and one eName happens to appear in both
+piles pointing at different places. The overlap is the conflict.
+
+<p>
+<svg viewBox="0 0 640 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two registries with one overlapping eName">
+  <rect x="10" y="10" width="620" height="300" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="6 6" rx="10"/>
+  <text x="24" y="34" font-size="14" fill="currentColor" font-weight="bold">Two registries, one clash</text>
+
+  <circle cx="240" cy="180" r="130" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="2"/>
+  <text x="180" y="100" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Registry A's records</text>
+
+  <circle cx="400" cy="180" r="130" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="2"/>
+  <text x="460" y="100" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Registry B's records</text>
+
+  <text x="155" y="190" text-anchor="middle" font-size="12" fill="currentColor">@alice</text>
+  <text x="155" y="208" text-anchor="middle" font-size="12" fill="currentColor">@bob</text>
+  <text x="155" y="226" text-anchor="middle" font-size="12" fill="currentColor">@carol</text>
+
+  <text x="485" y="190" text-anchor="middle" font-size="12" fill="currentColor">@dave</text>
+  <text x="485" y="208" text-anchor="middle" font-size="12" fill="currentColor">@eve</text>
+  <text x="485" y="226" text-anchor="middle" font-size="12" fill="currentColor">@frank</text>
+
+  <text x="320" y="180" text-anchor="middle" font-size="14" fill="currentColor" font-weight="bold">@same</text>
+  <text x="320" y="200" text-anchor="middle" font-size="11" fill="currentColor">two different</text>
+  <text x="320" y="214" text-anchor="middle" font-size="11" fill="currentColor">eVaults</text>
+  <text x="320" y="232" text-anchor="middle" font-size="11" fill="currentColor" font-style="italic">CONFLICT</text>
+</svg>
+</p>
+
+When the two registries next sync, both spot the overlap, both mark the
+entry as in conflict, and the resolution rules kick in.
+
+```mermaid
+flowchart TB
+    A["Creation record A<br/>witnessed at time T1"]
+    B["Creation record B<br/>witnessed at time T2"]
+    Detect{"Conflict spotted:<br/>two records,<br/>same eName"}
+    Compare{"Compare<br/>witnessed timestamps"}
+    Winner["Older record wins<br/>(if T1 is clearly earlier)"]
+    Review["Marked for review<br/>(if the two are too close)"]
+    Audit["Both outcomes get<br/>an audit log entry"]
+
+    A --> Detect
+    B --> Detect
+    Detect --> Compare
+    Compare --> Winner
+    Compare --> Review
+    Winner --> Audit
+    Review --> Audit
+```
+
+The rules:
+
+- The registry **must** detect the conflict and **must not** silently pick
+  one record.
+- The default winner is the record with the oldest **valid** creation
+  timestamp.
+- If the timestamps are too close, or the evidence is too thin, the entry is
+  marked `conflict_pending_review` and a human or policy decides.
+- Other inputs feed into the decision: first-seen evidence from trusted
+  registries, the reputation of the registries involved, any transfer
+  records, and the audit log.
+
+The conflict and its resolution are both written to the audit log, so the
+history is recoverable later.
+
+## What happens next
+
+Continue to [Requirements coverage](requirements-coverage) for a row-by-row
+map from each requirement to the part of these pages that satisfies it.

--- a/content/docs/architecture/identifiers/lifecycle.md
+++ b/content/docs/architecture/identifiers/lifecycle.md
@@ -5,39 +5,53 @@ weight: 3
 
 # Creation, resolution, transfer, conflicts
 
-A W3ID lives a whole life: it is created, it is looked up by other systems,
-it can be moved to a new eVault, and once in a while two people may
-accidentally pick the same one. This page walks through each of those four
-moments.
+A W3ID lives a whole life: it is created, it is registered, it is looked up
+by other systems, it can be moved to a new eVault, and once in a while
+someone may end up with the same one as you, by accident or on purpose. This
+page walks through each of those moments.
 
-## Creating a W3ID
+## Creation and registration are two separate steps
 
-A new W3ID is normally created at the moment a person, group, or device gets
-their first eVault. The wallet app generates the UUID, asks a small set of
-independent **timestamp witnesses** to vouch for the creation time, and then
-hands the whole creation record to a registry.
+Making a W3ID and registering it are **not** the same event, and it helps to
+keep them apart.
 
 > **In plain terms**
 >
-> When you make a new W3ID, you do not just pick a name. You also gather
-> signed notes from several independent timestamp services saying "yes, this
-> name first appeared at this moment". That makes it very hard for someone
-> else to come along later and claim they had it first.
+> Creating a W3ID is just picking a long random string of characters. Anyone
+> can do that on their own, offline, with no one watching. Registering it is
+> the separate step where it is announced to a registry so the rest of W3DS
+> can find it. The registry only gets involved at the second step, and it may
+> not even hear about a new eName until some time after it was created.
+
+### Step 1: creating the identifier
+
+A W3ID is created by sampling a random UUID. That is the whole of creation:
+no network, no registry, no witnesses are required just to bring an
+identifier into existence.
+
+### Step 2: registering a global eName
+
+To turn a freshly created W3ID into a resolvable **eName**, it is registered.
+This is normally done when a person, group, or device gets their first eVault.
+The **eVault** generates the UUID and asks a small set of independent
+**timestamp witnesses** to vouch for the creation time, then submits the
+creation record to a registry. The eVault, not the wallet, does this on
+purpose: an eVault has a reputation to protect and an interest in registering
+a genuinely unique identifier, whereas a throwaway wallet has nothing at stake
+and could mint a clashing identifier without consequence.
 
 ```mermaid
 sequenceDiagram
-    participant Wallet as Wallet (yours)
+    participant Vault as Your eVault
     participant Witnesses as Timestamp witnesses
-    participant Vault as eVault provisioning
     participant Registry as Registry
 
-    Wallet->>Wallet: 1. Pick a UUID at random
-    Wallet->>Witnesses: 2. Ask several to timestamp it
-    Witnesses-->>Wallet: 3. Signed time stamps
-    Wallet->>Vault: 4. Create my eVault
-    Wallet->>Registry: 5. Register the eName with the creation record
-    Registry->>Registry: 6. Check nobody else has it already
-    Registry-->>Wallet: 7. Done
+    Vault->>Vault: 1. Generate a UUID at random
+    Vault->>Witnesses: 2. Ask several to timestamp it
+    Witnesses-->>Vault: 3. Signed time stamps
+    Vault->>Registry: 4. Register the eName with the creation record
+    Registry->>Registry: 5. Verify the witnesses and check nobody else has it
+    Registry-->>Vault: 6. Registered
 ```
 
 A few rules from the requirements:
@@ -46,9 +60,20 @@ A few rules from the requirements:
 - The timestamp **should** be backed by signed witnesses, ideally a quorum
   like **7 out of 10** independent witnesses, so a single rogue witness
   cannot lie about the time.
-- The registry **must** do a best-effort check to see whether someone else
-  already registered the same name. The check is best-effort because a
-  conflict can still happen, see [Conflicts](#conflicts) below.
+- At registration the registry **must** verify the creation record and do a
+  best-effort check to see whether someone else already registered the same
+  name. The check is best-effort because a conflict can still happen, see
+  [Conflicts](#conflicts) below.
+
+### Creating a local W3ID
+
+A **local** W3ID is even simpler. It is created the same way (sample a random
+UUID), but it is **never registered**, because it only needs to be unique
+inside one eVault, not across the whole ecosystem. There are no witnesses and
+no registry involved. The eVault that owns it just makes sure it does not
+reuse a local UUID it has already used. A local W3ID only becomes globally
+findable if it is later promoted and registered, at which point it follows
+the global registration flow above.
 
 ### Reserving a W3ID for someone who is not on W3DS yet
 
@@ -114,11 +139,24 @@ The transfer record carries:
 A registry will only point your eName at the new eVault if the chain of
 transfer records links cleanly back to your original creation record.
 
+> **Out of scope: automatic failover to a backup eVault**
+>
+> Switching from a primary eVault to a backup copy is a related but separate
+> problem. It should ideally happen automatically, without a fresh manual
+> signature from the user, which would likely need pre-signed transfer
+> records prepared in advance. That mechanism is out of scope for this
+> identifiers section and is left for the eVault and recovery design.
+
 ## Conflicts
 
-Sometimes two creations slip past the duplicate check, for example because
-two registries were temporarily out of touch. The W3ID requirements treat
-duplicates as **conflicts**, never as something to be quietly merged.
+Sometimes two records end up claiming the same eName. This can happen by
+accident, for example because two registries were temporarily out of touch
+when each accepted a registration. It can also happen on purpose, when
+someone deliberately tries to register an eName that clashes with yours in
+order to impersonate you or hijack lookups. The W3ID requirements treat
+duplicates as **conflicts** either way, never as something to be quietly
+merged, and the oldest properly witnessed creation timestamp is what defeats
+a malicious latecomer.
 
 The picture below shows what a conflict actually is: two registries each
 hold their own pile of records, and one eName happens to appear in both

--- a/content/docs/architecture/identifiers/lifetime.md
+++ b/content/docs/architecture/identifiers/lifetime.md
@@ -1,0 +1,121 @@
+---
+title: How a W3ID stays the same
+weight: 2
+---
+
+# How a W3ID stays the same
+
+A W3ID is designed to last as long as the person, group, or device it
+identifies. The whole point is that other people, other apps, and other
+systems can use the same name to reach you for years and never have to update
+their records.
+
+The requirement document gives a target of **500 years or more**. That is the
+horizon we are designing for.
+
+> **In plain terms**
+>
+> A W3ID is more like a passport number than a phone number. You can lose
+> your phone, change carriers, or move countries; the passport number on file
+> at the embassy stays the same. A W3ID is the same idea, but for digital
+> services.
+
+## What can change without changing the W3ID
+
+```mermaid
+flowchart LR
+    subgraph Time["Can change over time"]
+        Key1["Phone keys"]
+        Vault1["Which eVault you use"]
+        Recover["Recovery from a lost device"]
+    end
+
+    W3ID(("Your W3ID<br/>stays the same"))
+
+    Key1 -. does not change .-> W3ID
+    Vault1 -. does not change .-> W3ID
+    Recover -. does not change .-> W3ID
+```
+
+Three things in particular can change underneath without ever changing your
+W3ID:
+
+- **Your keys.** Cryptographic keys can be rotated (replaced) at any time,
+  for example after losing a phone. The W3ID is **not** built from your
+  keys, so a new key does not produce a new W3ID.
+- **Your eVault.** You can move from one eVault provider to another (see
+  [Transfer](lifecycle#transferring-to-a-new-evault)). Your W3ID stays
+  the same, and lookups follow you.
+- **Recovery after a lost device.** If a small group of trusted people or
+  notaries vouch for you, you can install new keys on a new device and
+  carry on, all without changing your W3ID.
+
+## A W3ID is not a key
+
+The picture below sums up the rule: a W3ID, the keys you use to prove
+you are you, and the eVault that holds your data are three **separate**
+things. None of them is built from the others, so any one of them can
+change without breaking the other two.
+
+<p>
+<svg viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Three independent things: W3ID, keys, eVault">
+  <rect x="10" y="10" width="620" height="260" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="6 6" rx="10"/>
+  <text x="24" y="34" font-size="14" fill="currentColor" font-weight="bold">Three independent things</text>
+
+  <circle cx="140" cy="160" r="80" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="2"/>
+  <text x="140" y="155" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Your W3ID</text>
+  <text x="140" y="175" text-anchor="middle" font-size="12" fill="currentColor">never changes</text>
+
+  <circle cx="320" cy="160" r="80" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="2"/>
+  <text x="320" y="155" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Your keys</text>
+  <text x="320" y="175" text-anchor="middle" font-size="12" fill="currentColor">can be rotated</text>
+
+  <circle cx="500" cy="160" r="80" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="2"/>
+  <text x="500" y="155" text-anchor="middle" font-size="15" fill="currentColor" font-weight="bold">Your eVault</text>
+  <text x="500" y="175" text-anchor="middle" font-size="12" fill="currentColor">can be moved</text>
+
+  <text x="320" y="260" text-anchor="middle" font-size="12" fill="currentColor" font-style="italic">No overlap: changing one does not change the others.</text>
+</svg>
+</p>
+
+The W3ID is **not** derived from any key or password. This matters because:
+
+- Keys can be lost, stolen, or rotated. If the W3ID was built from a key,
+  losing the key would mean losing the identity.
+- A W3ID can exist **before** any key is created (for example when an
+  organisation reserves an eName for a person who has not joined yet).
+- A W3ID can identify something that has no key at all (for example a
+  reference to a real-world organisation).
+
+The key and the W3ID are linked through separate **key binding** records,
+which can be updated whenever keys change.
+
+## A person and their eVault are different things
+
+A person has an eName. The eVault that currently holds that person's data
+**also** has its own W3ID. They are kept separate on purpose.
+
+```mermaid
+flowchart LR
+    Person["Person<br/>(eName: @abc-...)"]
+    EVault1["eVault A<br/>(W3ID: @v1-...)"]
+    EVault2["eVault B<br/>(W3ID: @v2-...)"]
+
+    Person -- today --> EVault1
+    Person -. tomorrow .-> EVault2
+```
+
+- The **eName** is the long-lived reference to the person. Other systems
+  store this.
+- The **eVault W3ID** identifies one specific data store. If the person
+  moves to a new provider, a new eVault W3ID comes into play, but the
+  person's eName does not change.
+- That is why long-term references should use the person's **eName** rather
+  than whatever eVault happens to host them today.
+
+## Why this matters in one sentence
+
+If your name as far as the rest of W3DS is concerned can survive a lost
+phone, a switched provider, and a friend-assisted recovery, then your
+identity does not depend on any single piece of hardware, any single
+company, or any single key.

--- a/content/docs/architecture/identifiers/requirements-coverage.md
+++ b/content/docs/architecture/identifiers/requirements-coverage.md
@@ -1,0 +1,140 @@
+---
+title: Requirements coverage
+weight: 4
+---
+
+# Requirements coverage
+
+This page maps every published W3ID and eName requirement to the part of this
+section that satisfies it. It is meant to be read side by side with the
+source:
+
+[W3ID and eName Requirements](https://github.com/w3ds-docs/w3ds-docs/wiki/W3ID-eName-Requirements)
+
+Each row quotes the requirement and links to the explanation.
+
+## Section 2: Identifier syntax
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A W3ID MUST use UUID syntax based on RFC 4122." | [Anatomy: the shape](../anatomy/#the-shape) |
+| "A W3ID UUID string MUST include mandatory dashes in the standard UUID positions." | [Anatomy: rules to remember](../anatomy/#rules-to-remember) |
+| "A W3ID UUID string MUST be treated as case-insensitive." | [Anatomy: rules to remember](../anatomy/#rules-to-remember) |
+| Global W3IDs require an `@` prefix | [Anatomy: the shape](../anatomy/#the-shape) and [the three classes](../anatomy/#the-three-classes) |
+| Local W3IDs use `/` prefix or path segments within global W3ID URIs | [Anatomy: the shape](../anatomy/#the-shape) and [examples](../anatomy/#examples) |
+| "The identifier space MAY be expanded beyond UUID if future collision rates require it." | [Anatomy: rules to remember](../anatomy/#rules-to-remember) |
+
+## Section 3: Identifier classes
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A global W3ID MUST be resolvable via W3DS registries." | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) |
+| "A global W3ID MUST be globally unique after registry convergence." | [Lifecycle: conflicts](../lifecycle/#conflicts) (oldest valid creation timestamp wins) |
+| "A global W3ID MUST be suitable for long-term references." | [Lifetime: how a W3ID stays the same](../lifetime/) |
+| "A global W3ID MUST NOT depend on DNS for its semantic identity." | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) |
+| "A local W3ID MUST be unique inside its owning eVault." | [Anatomy: the three classes](../anatomy/#the-three-classes) |
+| "A local W3ID is not globally unique by itself." | [Anatomy: the three classes](../anatomy/#the-three-classes) |
+| Local W3IDs become globally addressable when scoped: `@<controller-or-evault-w3id>/<local-w3id>` | [Anatomy: examples](../anatomy/#examples) |
+| "A local W3ID MAY be promoted to a global W3ID through registry discovery." | [Anatomy: the three classes](../anatomy/#the-three-classes) |
+| Promotion conflicts trigger renaming or resolution procedures | [Lifecycle: conflicts](../lifecycle/#conflicts) |
+| "eName SHOULD be used as the public term for globally resolvable W3IDs where a name-like concept is useful." | [Overview: two words you will see a lot](../#two-words-you-will-see-a-lot) and [Anatomy: the three classes](../anatomy/#the-three-classes) |
+| "eName SHOULD primarily refer to people, organizations, groups, devices, eVault controllers, or other first-class entities." | [Overview: where W3IDs show up](../#where-w3ids-show-up) |
+| "eName MUST NOT imply that the identifier is derived from a cryptographic key." | [Lifetime: a W3ID is not a key](../lifetime/#a-w3id-is-not-a-key) |
+
+## Section 4: Persistence and lifetime
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A W3ID MUST be designed as a persistent identifier." | [Lifetime: how a W3ID stays the same](../lifetime/) |
+| "A W3ID SHOULD remain stable for the lifetime of the referenced entity." | [Lifetime: how a W3ID stays the same](../lifetime/) |
+| "The ecosystem SHOULD assume a target lifetime of 500+ years for long-term W3ID references." | [Lifetime: how a W3ID stays the same](../lifetime/) (opening paragraph) |
+| "A W3ID MUST remain stable across key rotation." | [Lifetime: what can change without changing the W3ID](../lifetime/#what-can-change-without-changing-the-w3id) |
+| "A W3ID SHOULD remain stable across eVault migration when the W3ID identifies a person, group, or controller rather than one physical eVault instance." | [Lifetime: a person and their eVault are different things](../lifetime/#a-person-and-their-evault-are-different-things) and [Lifecycle: transferring to a new eVault](../lifecycle/#transferring-to-a-new-evault) |
+
+## Section 5: Relationship to keys and identity
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A W3ID MUST NOT be intrinsically derived from a public/private key pair." | [Lifetime: a W3ID is not a key](../lifetime/#a-w3id-is-not-a-key) |
+| "A W3ID MAY be bound to public keys through key-binding certificates, binding documents, or similar records." | [Lifetime: a W3ID is not a key](../lifetime/#a-w3id-is-not-a-key) |
+| "A W3ID MAY exist before any public key is bound to it." | [Lifetime: a W3ID is not a key](../lifetime/#a-w3id-is-not-a-key) |
+| "A W3ID MAY identify an entity that has no key pair." | [Lifetime: a W3ID is not a key](../lifetime/#a-w3id-is-not-a-key) |
+| "User key material MUST be replaceable without changing the W3ID." | [Lifetime: what can change without changing the W3ID](../lifetime/#what-can-change-without-changing-the-w3id) |
+| Person eName should provide stable anchors between identity evidence, social attestations, and public keys | [Lifetime: a W3ID is not a key](../lifetime/#a-w3id-is-not-a-key) (last paragraph) |
+
+## Section 6: Relationship to eVaults
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "Each eVault MUST have its own globally unique W3ID." | [Lifetime: a person and their eVault are different things](../lifetime/#a-person-and-their-evault-are-different-things) |
+| "An eVault W3ID MUST be distinct from a user or group eName." | [Lifetime: a person and their eVault are different things](../lifetime/#a-person-and-their-evault-are-different-things) |
+| Long-term references prefer controller eName format over transient eVault W3ID | [Lifetime: a person and their eVault are different things](../lifetime/#a-person-and-their-evault-are-different-things) |
+| Resolution process: identify current active eVault for controller eName, then fetch local object | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) |
+
+## Section 7: W3ID URI resolution
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A W3ID URI MUST be dereferenceable through a registry when it starts with a global W3ID." | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) |
+| "The registry MUST resolve the global W3ID to the current eVault location." | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) |
+| "The eVault MUST resolve the local path component, if present." | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) (step 3 in the sequence diagram) |
+| "W3ID URIs SHOULD gradually replace DNS/URL references inside W3DS." | [Lifecycle: resolving a W3ID](../lifecycle/#resolving-a-w3id) (closing sentence) |
+
+## Section 8: Creation
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A person or group eName SHOULD normally be created during eVault provisioning." | [Lifecycle: creating a W3ID](../lifecycle/#creating-a-w3id) |
+| "The eVault MUST make a best-effort duplicate check before accepting a new global W3ID." | [Lifecycle: creating a W3ID](../lifecycle/#creating-a-w3id) (step 6 in the sequence diagram) |
+| Duplicate detection not guaranteed at creation; later conflict resolution required | [Lifecycle: conflicts](../lifecycle/#conflicts) |
+
+## Section 9: Creation timestamp
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "A global W3ID/eName creation record MUST include a creation timestamp." | [Lifecycle: creating a W3ID](../lifecycle/#creating-a-w3id) |
+| "The creation timestamp SHOULD be backed by a timestamp proof from one or more trusted timestamp witnesses." | [Lifecycle: creating a W3ID](../lifecycle/#creating-a-w3id) (steps 2 and 3) |
+| "For stronger guarantees, the ecosystem SHOULD support timestamp quorum, for example `7 of 10` witnesses." | [Lifecycle: creating a W3ID](../lifecycle/#creating-a-w3id) (rules list) |
+| Earlier valid creation timestamps have priority in conflicts unless superseded by valid transfer chain | [Lifecycle: conflicts](../lifecycle/#conflicts) |
+
+## Section 10: Transfer
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "Transfer of an eName from one eVault/controller to another MUST NOT be treated as a simple registry overwrite." | [Lifecycle: transferring to a new eVault](../lifecycle/#transferring-to-a-new-evault) |
+| "Transfer MUST be represented by a transfer record or transfer document." | [Lifecycle: transferring to a new eVault](../lifecycle/#transferring-to-a-new-evault) |
+| Transfer record fields (eName, previous and new eVault, effective time, original creation reference, document hash, signatures, authorisation evidence) | [Lifecycle: transferring to a new eVault](../lifecycle/#transferring-to-a-new-evault) (fields list) |
+| "A registry MUST accept a later target for an eName only when supported by a valid transfer chain." | [Lifecycle: transferring to a new eVault](../lifecycle/#transferring-to-a-new-evault) (last sentence) |
+
+## Section 11: Conflict and deduplication
+
+> Some pieces of this section are explicitly described as **prototype-level**
+> by the source document (for example, post-prototype merging behaviour). The
+> rows below mark those.
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "The ecosystem MUST treat duplicate global W3IDs/eNames as conflicts." | [Lifecycle: conflicts](../lifecycle/#conflicts) |
+| "Duplicates SHOULD be treated as bugs or malicious events until proven otherwise." | [Lifecycle: conflicts](../lifecycle/#conflicts) |
+| "Registries MUST detect conflicts where the same global W3ID/eName maps to different targets." | [Lifecycle: conflicts](../lifecycle/#conflicts) |
+| "A registry MUST NOT silently overwrite a conflicting existing record." | [Lifecycle: conflicts](../lifecycle/#conflicts) (rules list) |
+| Conflict resolution preference order: earlier creation timestamps, valid transfer chains, higher-reputation registry evidence, peer first-seen evidence | [Lifecycle: conflicts](../lifecycle/#conflicts) (rules list) |
+| Post-prototype deduplication may merge entities and update references (prototype-level) | [Lifecycle: conflicts](../lifecycle/#conflicts) (deferred to a later iteration) |
+
+## Section 12: External party assignment
+
+> This section is a `MAY`, supported as a prototype-level extension.
+
+| Requirement | Where it is satisfied |
+| --- | --- |
+| "The system MAY support assigning an eName to a person or organization that is not yet an active W3DS participant." | [Lifecycle: reserving a W3ID for someone who is not on W3DS yet](../lifecycle/#reserving-a-w3id-for-someone-who-is-not-on-w3ds-yet) |
+| External party records support identity evidence: legal name, passport numbers, addresses, dates of birth, photographs, organisation registration numbers | [Lifecycle: reserving a W3ID for someone who is not on W3DS yet](../lifecycle/#reserving-a-w3id-for-someone-who-is-not-on-w3ds-yet) |
+| "External party assignment SHOULD include deduplication checks." | [Lifecycle: reserving a W3ID for someone who is not on W3DS yet](../lifecycle/#reserving-a-w3id-for-someone-who-is-not-on-w3ds-yet) (last sentence) |
+
+## References
+
+- [W3ID and eName Requirements](https://github.com/w3ds-docs/w3ds-docs/wiki/W3ID-eName-Requirements)
+- [Overview](../) for the orientation diagram.
+- [Anatomy](../anatomy) for format and classes.
+- [Lifetime](../lifetime) for persistence and key independence.
+- [Lifecycle](../lifecycle) for creation, resolution, transfer, conflicts.

--- a/layouts/_markup/render-codeblock-mermaid.html
+++ b/layouts/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,18 @@
+{{- /* Project override: pick a mermaid theme that matches the active color scheme */ -}}
+<pre class="mermaid">{{ .Inner | htmlEscape | safeHTML -}}</pre>
+{{- if not (.Page.Store.Get "mermaid") -}}
+  {{- /* Include mermaid only the first time */ -}}
+  <script src="{{ "mermaid.min.js" | relURL }}"></script>
+  <script>
+    (function () {
+      var prefersDark = window.matchMedia
+        && window.matchMedia("(prefers-color-scheme: dark)").matches;
+      mermaid.initialize({
+        startOnLoad: true,
+        flowchart: { useMaxWidth: true },
+        theme: prefersDark ? "dark" : "default"
+      });
+    })();
+  </script>
+  {{- .Page.Store.Set "mermaid" true -}}
+{{- end -}}


### PR DESCRIPTION
## Summary

New Identifiers section under Architecture, written to satisfy the [W3ID and eName Requirements](https://github.com/w3ds-docs/w3ds-docs/wiki/W3ID-eName-Requirements).

Five pages:

- **Overview**: what a W3ID is and where it shows up.
- **Anatomy**: format, the three classes (Global W3ID, Local W3ID, eName), with a Venn diagram.
- **Lifetime**: persistence across key rotation and eVault migration, independence from keys, 500-year horizon.
- **Lifecycle**: creation with witnessed timestamps, resolution, transfer records, conflict detection and resolution.
- **Requirements coverage**: row-by-row matrix mapping every requirement in Sections 2 to 12 to where it is satisfied.

Also adds `layouts/_markup/render-codeblock-mermaid.html`: a project override that initialises mermaid with the dark theme under `prefers-color-scheme: dark`, so diagrams stay readable in both light and dark modes.

## Test plan

- [ ] `hugo server` and visit `/docs/architecture/identifiers/`; all five pages render.
- [ ] Diagrams readable in both light and dark mode.
- [ ] Cross-check the Requirements coverage matrix against the wiki page.