### PR TITLE
docs: redundant eVaults proposal

### DIFF
--- a/content/docs/architecture/redundant-evaults/_index.md
+++ b/content/docs/architecture/redundant-evaults/_index.md
@@ -1,0 +1,100 @@
+---
+title: Redundant eVaults
+weight: 43
+bookCollapseSection: true
+---
+
+# Redundant eVaults
+
+An [eVault](/docs/Infrastructure/eVault) holds a person's data. If that single
+eVault goes offline or loses a disk, the person is locked out or loses
+information. This section proposes making eVaults **durable** and **highly
+available** by giving every user **three eVault replicas**, run by independent
+providers, that hold the same data and cover for each other.
+
+> **In plain terms**
+>
+> Instead of keeping your data in one place, you keep three copies with three
+> different companies. You always reach them through one stable address, so you
+> never have to know which copy you are talking to. If one company has an
+> outage, the other two keep working, and the system quietly picks a new leader
+> without you noticing.
+
+## The three goals
+
+- **Durable**: once the system tells you a change is saved, that change is not
+  lost, even if a machine crashes a second later. This is the job of the
+  [Write-Ahead Log](durability).
+- **Redundant**: the same data lives on three independent eVaults at once, so
+  losing one changes nothing for the user. This is the job of
+  [replication](redundancy).
+- **Self-healing**: if the leader fails, the survivors promote a new leader
+  automatically and the old one rejoins later. This is the job of
+  [failover](failover).
+
+## The shape of the system
+
+One of the three replicas is the **primary**. It is the only one that accepts
+writes. The other two are **replicas**: they stay in sync with the primary and
+can serve reads. The user reaches all of this through a single **ingress**, a
+stable front door that knows which replica is currently the primary and routes
+each request to the right place.
+
+```mermaid
+flowchart TB
+    Client["Client / Platform"]
+    Ingress["Ingress<br/>(stable front door)"]
+
+    subgraph Replicas["Three independent eVault providers"]
+        P["Primary eVault<br/>(takes writes)"]
+        R1["Replica eVault B<br/>(reads, stays in sync)"]
+        R2["Replica eVault C<br/>(reads, stays in sync)"]
+    end
+
+    Client --> Ingress
+    Ingress -->|writes and reads| P
+    Ingress -->|reads| R1
+    Ingress -->|reads| R2
+    P -->|streams its log| R1
+    P -->|streams its log| R2
+```
+
+## The Registry stays dumb
+
+This design deliberately keeps the [Registry](/docs/Infrastructure/Registry)
+out of the picture. The user's eName does **not** point at any individual
+eVault. It resolves to the **ingress** and nothing else. Everything about which
+replica is primary, and any leader change during a failure, happens **behind**
+the ingress.
+
+```mermaid
+flowchart LR
+    EName["Your eName<br/>(@e4d909c2-...)"]
+    Registry["Registry"]
+    Ingress["Ingress"]
+    Set["The replica set<br/>(primary + 2 replicas)"]
+
+    EName --> Registry
+    Registry -->|always resolves to| Ingress
+    Ingress -->|routes behind the scenes| Set
+```
+
+Because the eName always resolves to the same ingress, a failover never
+changes anything the Registry stores. The Registry does not know or care which
+replica is primary. This also keeps the user's eName cleanly separate from the
+individual eVault W3IDs, exactly as described in
+[Identifiers](/docs/architecture/identifiers/lifetime/#a-person-and-their-evault-are-different-things):
+the eName is the long-lived reference to the person, and each replica eVault
+has its own distinct eVault W3ID underneath.
+
+> **A note on the ingress**
+>
+> The ingress must itself be made redundant, otherwise it becomes the new
+> single point of failure. In practice that means more than one ingress address
+> behind the same stable name. The important property for this proposal is that
+> the eName to ingress mapping is stable, so the Registry never has to change
+> during a failure.
+
+The next three pages cover each goal in turn:
+[durability](durability), [redundancy](redundancy), and
+[failover](failover).

--- a/content/docs/architecture/redundant-evaults/durability.md
+++ b/content/docs/architecture/redundant-evaults/durability.md
@@ -1,0 +1,101 @@
+---
+title: "Durability: the Write-Ahead Log"
+weight: 1
+---
+
+# Durability: the Write-Ahead Log
+
+Durability means one simple promise: once the system tells you a change is
+saved, that change will survive a crash. The way to keep that promise is a
+**Write-Ahead Log**, the same technique [PostgreSQL](https://www.postgresql.org/docs/current/wal-intro.html)
+uses.
+
+> **In plain terms**
+>
+> Before the eVault touches the actual data, it first writes down what it is
+> about to do in a log, and makes sure that log entry is safely on disk. Only
+> then does it make the change and tell you "saved". If the power goes out a
+> moment later, the eVault reads its log back when it restarts and re-does any
+> change that was written down but not yet finished. Nothing you were told was
+> saved can be lost.
+
+## Write the log first, then the data
+
+The rule that gives the technique its name is that the log is **written ahead**
+of the data. Every change follows the same order.
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant Ingress as Ingress
+    participant Primary as Primary eVault
+
+    Client->>Ingress: Save this change
+    Ingress->>Primary: Save this change
+    Primary->>Primary: 1. Append the change to the log
+    Primary->>Primary: 2. Make the log entry durable on disk
+    Primary->>Primary: 3. Apply the change to the stored data
+    Primary-->>Ingress: 4. Saved
+    Ingress-->>Client: Saved
+```
+
+The acknowledgement at step 4 only goes out **after** step 2. That is the whole
+trick: the moment you are told "saved", the change is already safely recorded,
+even if the eVault crashes before step 3 finishes. On restart it replays the
+log and completes any half-applied change.
+
+## This builds on what the eVault already has
+
+The prototype eVault already keeps an append-only record of every operation at
+its [`/logs` endpoint](/docs/Infrastructure/eVault#logs): one entry per create,
+update, or delete, each with the affected envelope, a content hash, the
+operation type, the platform, and a timestamp.
+
+The Write-Ahead Log promotes that existing log from a side record into the
+**durable source of truth**. Each entry also carries an ever-increasing
+**sequence number** so the entries have a strict order. Everything downstream,
+replication and failover included, is built on replaying these numbered entries
+in order. The stored data is just the result of applying the log; the log is
+what actually has to survive.
+
+## Recovery after a crash
+
+When an eVault restarts, it does not trust its stored data blindly. It finds
+the last point it knows is fully written (a **checkpoint**), then replays every
+log entry after that point up to the end of the log. Anything acknowledged is
+in the log, so anything acknowledged is restored.
+
+```mermaid
+flowchart LR
+    Crash["eVault restarts<br/>after a crash"]
+    Checkpoint["Find the last<br/>checkpoint"]
+    Replay["Replay every log<br/>entry after it"]
+    Ready["Back in sync,<br/>nothing lost"]
+
+    Crash --> Checkpoint --> Replay --> Ready
+```
+
+## Making the log trustworthy across independent providers
+
+Because the three replicas are run by **independent providers**, a replica
+cannot simply be trusted to store the log honestly. A faulty or malicious
+provider could try to drop an entry, reorder entries, or invent one. The log is
+made **tamper-evident** to stop this:
+
+- Each log entry includes the **hash of the previous entry**, so the entries
+  form an unbroken chain. Removing or reordering any entry breaks the chain and
+  is immediately visible.
+- Each entry is **signed by the primary eVault**. A replica cannot fabricate an
+  entry the primary never produced, because it cannot forge that signature.
+
+> **In plain terms**
+>
+> Every page of the log is stamped with a fingerprint of the page before it,
+> and signed. If anyone tears out a page, swaps two pages, or slips in a fake
+> page, the fingerprints stop matching and everyone can see the log was
+> tampered with.
+
+This is what lets three independent companies safely hold the same data without
+a heavy voting protocol between them: the log carries its own proof that it is
+complete and in order. The next page, [redundancy](redundancy), shows how the
+primary streams this log to the other two replicas.

--- a/content/docs/architecture/redundant-evaults/failover.md
+++ b/content/docs/architecture/redundant-evaults/failover.md
@@ -1,0 +1,129 @@
+---
+title: "Failover: self-healing"
+weight: 3
+---
+
+# Failover: self-healing
+
+Failover is what happens when the primary goes away. The system should pick a
+new primary on its own, lose no acknowledged data, and let the old primary
+rejoin later. This page covers both the calm case and the crash case.
+
+> **In plain terms**
+>
+> If the leader copy stops working, the other two copies notice, agree on which
+> of them is most up to date, and make that one the new leader. The ingress
+> starts sending writes to the new leader. When the broken one comes back, it
+> quietly rejoins as a follower and catches up. You keep working the whole
+> time.
+
+## Two kinds of failover
+
+### Planned switchover (graceful)
+
+Sometimes a provider needs to take the primary down on purpose, for example for
+maintenance. There is no need to lose anything.
+
+1. The primary stops accepting new writes.
+2. It waits until both replicas have caught up to the very end of its log.
+3. It hands the primary role to a chosen replica.
+4. The ingress starts routing writes to the new primary.
+
+Because the replicas were fully caught up before the handover, **zero data is
+lost** and there is no scramble.
+
+### Unplanned failover (crash)
+
+Sometimes the primary just disappears, for example a server crash or a network
+cut. The replicas detect this because the primary stops answering regular
+**heartbeats**.
+
+```mermaid
+sequenceDiagram
+    participant Ingress as Ingress
+    participant P as Primary (crashes)
+    participant B as Replica B
+    participant C as Replica C
+
+    Note over P: Primary stops responding
+    B->>P: heartbeat (no reply)
+    C->>P: heartbeat (no reply)
+    B->>C: Compare how far our logs reach
+    C->>B: Compare how far our logs reach
+    Note over B,C: B has the furthest valid log
+    B->>B: Promote self to primary
+    B->>Ingress: I am the new primary
+    Ingress->>Ingress: Route writes to B
+    Note over Ingress: Service continues on B
+```
+
+The replica chosen as the new primary is the one whose **verified log reaches
+furthest**, that is, the one holding the longest valid signed chain of entries
+(see [durability](durability/#making-the-log-trustworthy-across-independent-providers)).
+Picking the most up-to-date log matters: under the default
+[quorum-synchronous](redundancy/#quorum-synchronous-the-default) setting every
+acknowledged write is already on at least one replica, and that replica's log
+reaches at least as far as the write, so the new primary still has it. No
+acknowledged write is lost.
+
+## Only one primary at a time
+
+The danger during a failure is **split-brain**: two eVaults both believing they
+are primary and both taking writes, which would split the data into two
+diverging copies. This design prevents it in two ways:
+
+- A replica only becomes primary with the **agreement of a majority** of the
+  three. A single replica cannot promote itself alone.
+- The **ingress routes writes to exactly one primary**. An old primary that was
+  cut off from the others cannot keep serving writes through the ingress,
+  because the ingress has already moved on. The old primary is **fenced off**:
+  it is no longer allowed to act as primary until it rejoins properly.
+
+> **In plain terms**
+>
+> There can only ever be one leader. A copy can only become leader if most of
+> the copies agree, and the front door only ever sends writes to that one
+> leader, so a confused old leader cannot keep taking changes on the side.
+
+## The old primary rejoins
+
+When the failed node comes back to life, it rejoins as a **replica**, not as
+the primary. There is one subtlety: if it had acknowledged a few writes to
+itself that never reached the others before it crashed (only possible under the
+asynchronous setting), its log has a short tail that diverges from the new
+primary's log.
+
+It handles this by **rewinding** that divergent tail and then catching up from
+the new primary, the same idea PostgreSQL calls `pg_rewind`. The hash-chain in
+the log makes the exact point where the two logs diverge easy to find: it is the
+first entry whose fingerprints stop matching.
+
+```mermaid
+flowchart LR
+    Back["Old primary<br/>comes back"]
+    Rejoin["Rejoins as a replica"]
+    Find["Find where its log<br/>diverged (broken chain link)"]
+    Rewind["Rewind the divergent tail"]
+    Catch["Catch up from<br/>the new primary"]
+
+    Back --> Rejoin --> Find --> Rewind --> Catch
+```
+
+## What clients and platforms see
+
+- **Reads** keep working throughout, served by whichever replicas are alive.
+- **A write in flight** at the instant of a crash may need to be retried; the
+  client simply sends it again and the ingress routes it to the new primary.
+- **Webhooks fire once.** The [Awareness Protocol](/docs/W3DS%20Protocol/Awareness-Protocol)
+  notification for a committed change is sent by whoever is primary once the
+  change is durable, and it is keyed by the change's log position. A failover in
+  the middle therefore cannot make the same change notify twice or go
+  un-notified.
+
+## The Registry never moves
+
+None of this touches the [Registry](/docs/Infrastructure/Registry). Throughout a
+failover the user's eName still resolves to the **same ingress**. The leader
+changing, the old primary rejoining, the rewind, all of it happens behind the
+ingress. From the outside, the user's address never changed, which is exactly
+the point of keeping the Registry dumb (see the [Overview](../#the-registry-stays-dumb)).

--- a/content/docs/architecture/redundant-evaults/redundancy.md
+++ b/content/docs/architecture/redundant-evaults/redundancy.md
@@ -1,0 +1,106 @@
+---
+title: "Redundancy: replication"
+weight: 2
+---
+
+# Redundancy: replication
+
+Redundancy means the same data lives on more than one machine at the same time,
+so losing one machine loses nothing. The three eVaults stay identical by sharing
+one thing: the [Write-Ahead Log](durability).
+
+> **In plain terms**
+>
+> The primary copy keeps a running log of every change. It sends that same log
+> to the other two copies, and they apply the changes in the same order. Do the
+> same steps in the same order and you end up in the same place, so all three
+> copies stay identical.
+
+## The primary streams its log to the replicas
+
+The primary is the only eVault that accepts writes. Every change it makes goes
+into its log, and it ships each new log entry to the two replicas as it is
+produced. The replicas apply the entries in order and so track the primary
+exactly. Reads can be served by any of the three, which also spreads the load.
+
+```mermaid
+flowchart TB
+    Client["Client"]
+    Ingress["Ingress"]
+    P["Primary eVault"]
+    B["Replica B"]
+    C["Replica C"]
+
+    Client -->|write| Ingress --> P
+    P -->|log entries| B
+    P -->|log entries| C
+    B -.->|confirms| P
+    C -.->|confirms| P
+```
+
+## How durable is "saved": you choose
+
+When the primary tells a client "saved", how much should have happened first?
+There is a genuine trade-off here, so it is **configurable per eVault**.
+
+### Quorum-synchronous (the default)
+
+The primary waits until **at least one replica** has also stored the log entry
+durably before it acknowledges the write.
+
+- **Benefit**: an acknowledged write now exists on at least two of the three
+  machines. If any single machine dies, the write is still there. Nothing you
+  were told was saved can be lost.
+- **Cost**: each write waits for one network round trip to a replica, so it is
+  a little slower.
+
+This is the default because the whole point of the design is durability.
+
+### Asynchronous (opt in)
+
+The primary acknowledges as soon as **its own** log entry is durable, and ships
+to the replicas in the background.
+
+- **Benefit**: writes are as fast as a single machine; no waiting for anyone
+  else.
+- **Cost**: if the primary crashes in the brief window before a write reaches a
+  replica, that newest write can be lost.
+
+An eVault that values latency over the last few writes can opt into this.
+
+```mermaid
+flowchart LR
+    subgraph Sync["Quorum-synchronous (default)"]
+        S1["Primary stores log"] --> S2["Wait for one<br/>replica to confirm"] --> S3["Acknowledge"]
+    end
+    subgraph Async["Asynchronous (opt in)"]
+        A1["Primary stores log"] --> A2["Acknowledge"]
+        A2 -.->|later| A3["Replicas catch up"]
+    end
+```
+
+## Replicas check every entry before applying it
+
+Because the providers are independent, a replica does not blindly trust what it
+receives. For every log entry the primary streams, the replica:
+
+- checks that the entry's **signature** really comes from the primary, and
+- checks that the entry's **previous-entry hash** matches the entry it already
+  holds, so nothing was skipped or reordered.
+
+If either check fails, the replica refuses the entry and raises the alarm rather
+than corrupting its copy. This is the same tamper-evidence described on the
+[durability page](durability/#making-the-log-trustworthy-across-independent-providers),
+now doing its job during replication.
+
+## Reads and replication lag
+
+A replica can be a moment behind the primary, because the latest entries may
+still be in flight. For most reads this does not matter. When it does matter,
+for example when a client wants to read back something it just wrote, the
+ingress routes that client's read to the primary, or to a replica it knows has
+already caught up to that write. This keeps the simple guarantee that you can
+always read your own latest change.
+
+The next page, [failover](failover), covers what happens when the primary
+itself goes away.


### PR DESCRIPTION
> Draft. A proposal for making eVaults durable and highly available. Open for discussion before it is finalised.

## Summary

Proposes giving every user **three eVault replicas**, run by independent providers, that hold the same data and cover for each other. New section under Architecture, four pages:

- **Overview**: the primary plus two replicas model behind a stable ingress, the three goals (durable, redundant, self-healing), and why the Registry stays out of it.
- **Durability**: a Postgres-style Write-Ahead Log. Writes go to an append-only log and are made durable before they are acknowledged. Builds on the eVault's existing `/logs`. The log is hash-chained and signed so it is tamper-evident across independent providers.
- **Redundancy**: the primary streams its log to the two replicas. Commit durability is configurable per eVault: quorum-synchronous by default (an acknowledged write survives any single failure), asynchronous as an opt-in for lower latency.
- **Failover**: planned switchover and crash failover, electing the replica with the furthest verified log, split-brain prevention, and the old primary rejoining with a rewind.

## Design decisions baked in

- Replicas are **independent providers**, so the log is tamper-evident rather than merely trusted.
- The user's eName resolves to a **stable ingress**, not to any eVault. Failover happens behind the ingress, so the **Registry never changes** during a failure.
- Conceptual level: diagrams and flows, no byte-level formats or election pseudocode.

## Open questions for reviewers

- How the ingress itself is made redundant without reintroducing a single point of failure.
- Whether quorum-synchronous is the right default, or whether it should wait for both replicas.
- How fencing of a partitioned old primary is enforced in 